### PR TITLE
Fix performance issues when enabling/disabling large numbers of items

### DIFF
--- a/ros_network_viz/ros_graph.py
+++ b/ros_network_viz/ros_graph.py
@@ -566,7 +566,7 @@ class ROSGraph:
                     nodeinfo.set_component_manager(True)
 
                 if 'list_parameters' in service_name and \
-                   service_type =='rcl_interfaces/srv/ListParameters':
+                   service_type == 'rcl_interfaces/srv/ListParameters':
                     has_list_parameter = True
 
                 if 'get_parameters' in service_name and \
@@ -635,7 +635,8 @@ class ROSGraph:
             # them somehow to the user
 
             if has_param_services and fully_qualified_name not in self._param_state_machines:
-                self._param_state_machines[fully_qualified_name] = ROSParameterStateMachine(self._node, fully_qualified_name)
+                psm = ROSParameterStateMachine(self._node, fully_qualified_name)
+                self._param_state_machines[fully_qualified_name] = psm
 
             nodes[fully_qualified_name] = nodeinfo
 


### PR DESCRIPTION
It turns out that we were emitting separate repaint events for every single item when we enabled/disabled large groups of items.  This caused us to run through the loop there many times, doing a lot of extra work.  Instead of that, batch up all of the changes into one, and cause the redraw to happen just once, which is a lot faster.

This should fix #15