### PR TITLE
Add an arrow to the connection lines to indicate data flow direction

### DIFF
--- a/ros_network_viz/ros_network_viz.py
+++ b/ros_network_viz/ros_network_viz.py
@@ -94,7 +94,6 @@ class ConnectionLine(QtWidgets.QGraphicsPathItem):
         self.setPen(self._pen)
 
         # The connection line begins in the unselected state
-        self._selected = False
         self._current_brush = self._brush
 
         # The endpoints of the connection line aren't known until update_path is called
@@ -104,14 +103,12 @@ class ConnectionLine(QtWidgets.QGraphicsPathItem):
     def hoverEnterEvent(self, event):
         self.setPen(self._pen_sel)
         self._current_brush = self._brush_sel
-        self._selected = True
         super().hoverEnterEvent(event)
 
     # PyQt method override
     def hoverLeaveEvent(self, event):
         self.setPen(self._pen)
         self._current_brush = self._brush
-        self._selected = False
         super().hoverLeaveEvent(event)
 
     def update_path(self, source_point, target_point):

--- a/ros_network_viz/ros_network_viz.py
+++ b/ros_network_viz/ros_network_viz.py
@@ -111,19 +111,6 @@ class ConnectionLine(QtWidgets.QGraphicsPathItem):
         self._current_brush = self._brush
         super().hoverLeaveEvent(event)
 
-    def update_path(self, source_point, target_point):
-        path = QtGui.QPainterPath()
-
-        self._arrow_location = target_point
-        path.moveTo(source_point)
-        dx = (target_point.x() - source_point.x()) * 0.5
-        dy = target_point.y() - source_point.y()
-        ctrl1 = QtCore.QPointF(source_point.x() + dx, source_point.y() + dy * 0)
-        ctrl2 = QtCore.QPointF(source_point.x() + dx, source_point.y() + dy * 1)
-        path.cubicTo(ctrl1, ctrl2, target_point)
-
-        self.setPath(path)
-
     # PyQt method override
     def paint(self, painter, option, widget):
         super().paint(painter, option, widget)
@@ -138,6 +125,19 @@ class ConnectionLine(QtWidgets.QGraphicsPathItem):
             path.lineTo(x + 1, y)
             path.moveTo(x - 15, y + 10)
             painter.fillPath(path, self._current_brush)
+
+    def update_path(self, source_point, target_point):
+        path = QtGui.QPainterPath()
+
+        self._arrow_location = target_point
+        path.moveTo(source_point)
+        dx = (target_point.x() - source_point.x()) * 0.5
+        dy = target_point.y() - source_point.y()
+        ctrl1 = QtCore.QPointF(source_point.x() + dx, source_point.y() + dy * 0)
+        ctrl2 = QtCore.QPointF(source_point.x() + dx, source_point.y() + dy * 1)
+        path.cubicTo(ctrl1, ctrl2, target_point)
+
+        self.setPath(path)
 
 
 class NodeBox(QtWidgets.QGraphicsObject):


### PR DESCRIPTION
Known limitations:
* The arrow doesn't track the orientation of the line
* When multiple connection lines go into the same topic box, the highlighted connection line may not be on top in the Z-order (and so the arrow isn't the highlighted color)

Fixes #7 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>